### PR TITLE
[BE-#514] DLT 구현 및 재시도 로직 추가

### DIFF
--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/config/KafkaConsumerConfig.java
@@ -1,21 +1,34 @@
 package com.icestudyroom_email.domain.email.infrastructure.kafka.config;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.ExponentialBackOff;
 
 import java.util.Map;
 
 @Configuration
 @EnableKafka
 public class KafkaConsumerConfig {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public KafkaConsumerConfig(KafkaTemplate<String, Object> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
 
     @Bean
     public ConsumerFactory<String, Object> consumerFactory(KafkaProperties properties) {
@@ -33,8 +46,26 @@ public class KafkaConsumerConfig {
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
             ConsumerFactory<String, Object> consumerFactory) {
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+                kafkaTemplate,
+                (record, ex) -> new TopicPartition(record.topic() + ".DLT", -1)
+        );
+
+        ExponentialBackOff backOff = new ExponentialBackOff(1000L, 2.0);
+        backOff.setMaxElapsedTime(10000L);
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+
+        errorHandler.addNotRetryableExceptions(
+                NullPointerException.class,
+                IllegalArgumentException.class,
+                JsonParseException.class,
+                HttpMessageNotReadableException.class
+        );
+
         ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory);
+        factory.setCommonErrorHandler(errorHandler);
+
         return factory;
     }
 }

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/DltConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/DltConsumer.java
@@ -1,0 +1,29 @@
+package com.icestudyroom_email.domain.email.infrastructure.kafka.consumer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class DltConsumer {
+
+    @KafkaListener(topics = "vacancy-notifications.DLT", groupId = "dlt-group", containerFactory = "kafkaListenerContainerFactory")
+    public void consumeDlt(
+        ConsumerRecord<String, String> record,
+        @Header(KafkaHeaders.DLT_EXCEPTION_MESSAGE) String exceptionMessage,
+        @Header(KafkaHeaders.DLT_EXCEPTION_STACKTRACE) String stacktrace,
+        @Header(KafkaHeaders.DLT_ORIGINAL_TOPIC) String originalTopic,
+        @Header(KafkaHeaders.DLT_ORIGINAL_OFFSET) long originalOffset
+    ) {
+        log.error("[DLT] 최종 처리 실패 메시지 수신");
+        log.error("  - Original Topic: {}", originalTopic);
+        log.error("  - Original Offset: {}", originalOffset);
+        log.error("  - Exception: {}", exceptionMessage);
+        log.error("  - Failed Message Payload: {}", record.value());
+        log.error("  - Stacktrace: {}", stacktrace);
+    }
+}

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/EmailEventConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/EmailEventConsumer.java
@@ -1,4 +1,4 @@
-package com.icestudyroom_email.domain.email.infrastructure.kafka;
+package com.icestudyroom_email.domain.email.infrastructure.kafka.consumer;
 
 import com.icestudyroom_email.domain.email.infrastructure.gmail.EmailService;
 import com.icestudyroom_email.domain.email.infrastructure.gmail.dto.EmailRequest;
@@ -19,10 +19,16 @@ public class EmailEventConsumer {
     public void listenVacancyNotification(VacancyNotificationRequest notificationRequest) {
         log.info("빈자리 알림 서비스 수행, 방 번호: {}", notificationRequest.getRoomName());
 
-        String emailBody = createEmailBody(notificationRequest);
-        EmailRequest emailRequest = new EmailRequest(notificationRequest.getEmail(), "[ICE-STUDYRES] 빈자리 알림", emailBody);
+        try {
+            String emailBody = createEmailBody(notificationRequest);
+            EmailRequest emailRequest = new EmailRequest(notificationRequest.getEmail(), "[ICE-STUDYRES] 빈자리 알림", emailBody);
 
-        emailService.sendEmail(emailRequest);
+            emailService.sendEmail(emailRequest);
+            log.info("이메일 발송 성공, 받는 사람: {}", notificationRequest.getEmail());
+        } catch (Exception e) {
+            log.error("이메일 발송 처리 중 에러 발생. 받는 사람: {}, 에러: {}", notificationRequest.getEmail(), e.getMessage());
+            throw e;
+        }
     }
 
     private String createEmailBody(VacancyNotificationRequest dto) {


### PR DESCRIPTION
## PR 종류
- [x] 새로운 기능


## 변경 사항

- 컨슈머에서 SMTP에 요청한 작업이 실패할 경우 재시도 로직 추가
  - 재시도 간의 대기시간은 지수적으로 상승합니다.
  - 10초 뒤에도 실패로 마무리 될 경우 DLT로 메세지 전달 및 로깅

## 관련 이슈
- #514

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용
### 컨슈머에서 예외가 발생할 경우 DLT 처리 및 재시도 로직 추가
```java
    @Bean
    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
            ConsumerFactory<String, Object> consumerFactory) {
        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
                kafkaTemplate,
                (record, ex) -> new TopicPartition(record.topic() + ".DLT", -1)
        );

        ExponentialBackOff backOff = new ExponentialBackOff(1000L, 2.0);
        backOff.setMaxElapsedTime(10000L);
        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);

        errorHandler.addNotRetryableExceptions(
                NullPointerException.class,
                IllegalArgumentException.class,
                JsonParseException.class,
                HttpMessageNotReadableException.class
        );

        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
        factory.setConsumerFactory(consumerFactory);
        factory.setCommonErrorHandler(errorHandler);

        return factory;
    }
```
- 재시도를 1분간 1 -> 2 -> 4로 x의 2승의 그래프를 따라가게 구현
- 외부 API를 호출하는 작업이기에 예의 있는 호출이 필요합니다. 따라서 회복할 시간을 주기 위해서 지수적 백오프를 선택했습니다.

### DLT
```java
@Slf4j
@Component
public class DltConsumer {

    @KafkaListener(topics = "vacancy-notifications.DLT", groupId = "dlt-group", containerFactory = "kafkaListenerContainerFactory")
    public void consumeDlt(
        ConsumerRecord<String, String> record,
        @Header(KafkaHeaders.DLT_EXCEPTION_MESSAGE) String exceptionMessage,
        @Header(KafkaHeaders.DLT_EXCEPTION_STACKTRACE) String stacktrace,
        @Header(KafkaHeaders.DLT_ORIGINAL_TOPIC) String originalTopic,
        @Header(KafkaHeaders.DLT_ORIGINAL_OFFSET) long originalOffset
    ) {
        log.error("[DLT] 최종 처리 실패 메시지 수신");
        log.error("  - Original Topic: {}", originalTopic);
        log.error("  - Original Offset: {}", originalOffset);
        log.error("  - Exception: {}", exceptionMessage);
        log.error("  - Failed Message Payload: {}", record.value());
        log.error("  - Stacktrace: {}", stacktrace);
    }
}
```
- 실패한 메세지에 대한 로깅 작업을 DLT에서 수행합니다.

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
