### PR TITLE
[BE-#524] 컨슈머 멱등성 보장 및 로깅 기능 추가

### DIFF
--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/config/KafkaConsumerConfig.java
@@ -12,6 +12,7 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
@@ -65,6 +66,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory);
         factory.setCommonErrorHandler(errorHandler);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
 
         return factory;
     }

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/DltConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/DltConsumer.java
@@ -20,10 +20,10 @@ public class DltConsumer {
         @Header(KafkaHeaders.DLT_ORIGINAL_OFFSET) long originalOffset
     ) {
         log.error("[DLT] 최종 처리 실패 메시지 수신");
-        log.error("  - Original Topic: {}", originalTopic);
-        log.error("  - Original Offset: {}", originalOffset);
-        log.error("  - Exception: {}", exceptionMessage);
-        log.error("  - Failed Message Payload: {}", record.value());
-        log.error("  - Stacktrace: {}", stacktrace);
+        log.error("  - 토픽: {}", originalTopic);
+        log.error("  - 오프셋: {}", originalOffset);
+        log.error("  - 예외 메세지: {}", exceptionMessage);
+        log.error("  - 예외 본문: {}", record.value());
+        log.error("  - 스택 트레이스: {}", stacktrace);
     }
 }

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/EmailEventConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/EmailEventConsumer.java
@@ -6,46 +6,185 @@ import com.icestudyroom_email.domain.email.infrastructure.kafka.dto.VacancyNotif
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class EmailEventConsumer {
-    private final static String reservationLink = "http://localhost:5173/reservation/room";
+    private final static String reservationLink = "https://ice-studyroom.com";
     private final EmailService emailService;
 
+    private final Set<String> processedMessageIds = ConcurrentHashMap.newKeySet();
+    private static final int MAX_PROCESSED_IDS = 50000;
+    private final AtomicInteger messageCounter = new AtomicInteger(0);
+
+    private final AtomicInteger successCount = new AtomicInteger(0);
+    private final AtomicInteger failureCount = new AtomicInteger(0);
+    private final AtomicInteger duplicateCount = new AtomicInteger(0);
+    private volatile long lastProcessTime = System.currentTimeMillis();
+
     @KafkaListener(topics = "vacancy-notifications", groupId = "email-service-group", containerFactory = "kafkaListenerContainerFactory")
-    public void listenVacancyNotification(VacancyNotificationRequest notificationRequest) {
-        log.info("빈자리 알림 서비스 수행, 방 번호: {}", notificationRequest.getRoomName());
+    public void listenVacancyNotification(VacancyNotificationRequest notificationRequest, Acknowledgment ack) {
+        lastProcessTime = System.currentTimeMillis();
+
+        log.info("[KAFKA] 빈자리 알림 수신 - 스케줄:{}, 방:{}, 이메일:{}",
+                notificationRequest.getScheduleId(),
+                notificationRequest.getRoomName(),
+                maskEmail(notificationRequest.getEmail()));
+
+        String idempotencyKey = generateIdempotencyKey(notificationRequest);
+
+        if (!processedMessageIds.add(idempotencyKey)) {
+            duplicateCount.incrementAndGet();
+            log.warn("[DUPLICATE] 중복 메시지 차단 - 키:{}", idempotencyKey);
+            logMonitoringStats();
+            ack.acknowledge();
+            return;
+        }
 
         try {
+            String subject = createEmailSubject(notificationRequest);
             String emailBody = createEmailBody(notificationRequest);
-            EmailRequest emailRequest = new EmailRequest(notificationRequest.getEmail(), "[ICE-STUDYRES] 빈자리 알림", emailBody);
+            EmailRequest emailRequest = new EmailRequest(notificationRequest.getEmail(), subject, emailBody);
 
+            long startTime = System.currentTimeMillis();
             emailService.sendEmail(emailRequest);
-            log.info("이메일 발송 성공, 받는 사람: {}", notificationRequest.getEmail());
+            long endTime = System.currentTimeMillis();
+
+            successCount.incrementAndGet();
+            ack.acknowledge();
+
+            log.info("[SUCCESS] 이메일 발송 성공 - 스케줄:{}, 수신자:{}, 소요시간:{}ms",
+                    notificationRequest.getScheduleId(),
+                    maskEmail(notificationRequest.getEmail()),
+                    (endTime - startTime));
+
         } catch (Exception e) {
-            log.error("이메일 발송 처리 중 에러 발생. 받는 사람: {}, 에러: {}", notificationRequest.getEmail(), e.getMessage());
+            failureCount.incrementAndGet();
+            processedMessageIds.remove(idempotencyKey);
+
+            log.error("[FAILURE] 이메일 발송 실패 - 스케줄:{}, 수신자:{}, 에러:{}",
+                    notificationRequest.getScheduleId(),
+                    maskEmail(notificationRequest.getEmail()),
+                    e.getMessage());
+
             throw e;
         }
+
+        int currentCount = messageCounter.incrementAndGet();
+
+        // 100개마다 모니터링 로그 출력
+        if (currentCount % 100 == 0) {
+            logMonitoringStats();
+        }
+
+        // 1000개마다 cleanup 체크
+        if (currentCount % 1000 == 0) {
+            cleanupIfNeeded();
+        }
+    }
+
+    private void cleanupIfNeeded() {
+        if (processedMessageIds.size() > MAX_PROCESSED_IDS) {
+            // 절반 정리 (오래된 것부터)
+            int removeCount = processedMessageIds.size() / 2;
+            Iterator<String> iterator = processedMessageIds.iterator();
+
+            for (int i = 0; i < removeCount && iterator.hasNext(); i++) {
+                iterator.next();
+                iterator.remove();
+            }
+
+            log.info("메모리 정리 완료 - 제거된 항목: {}, 남은 항목: {}",
+                    removeCount, processedMessageIds.size());
+        }
+    }
+
+    private String generateIdempotencyKey(VacancyNotificationRequest request) {
+        return String.format("schedule-%d-email-%s-time-%d",
+                request.getScheduleId(),
+                request.getEmail(),
+                request.getTimestamp());
+    }
+
+    private String createEmailSubject(VacancyNotificationRequest dto) {
+        return String.format("[ICE-STUDYRES] %s %s-%s 빈자리 알림",
+                dto.getRoomName(),
+                dto.getStartTime(),
+                dto.getEndTime());
     }
 
     private String createEmailBody(VacancyNotificationRequest dto) {
         return String.format(
-                "<html><body>" +
-                        "<h2>빈자리 알림</h2>" +
-                        "<hr>" +
-                        "<p><strong>%s %s</strong>에 빈자리가 생겼습니다.</p>" +
-                        "<p>아래 링크에 접속하시면 빠르게 예약하실 수 있습니다.</p>" +
-                        "<p><strong>링크:</strong> <a href=\"%s\">%s</a></p>" +
-                        "<hr>" +
-                        "<p>감사합니다.</p>" +
+                "<html><body style='font-family: Arial, sans-serif; line-height: 1.6; color: #333;'>" +
+                        "<div style='max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px;'>" +
+                        "<h2 style='color: #2c5aa0; text-align: center; margin-bottom: 30px;'>🏫 빈자리 알림</h2>" +
+                        "<hr style='border: none; height: 2px; background: linear-gradient(to right, #2c5aa0, #87ceeb); margin: 20px 0;'>" +
+
+                        "<div style='background-color: #f8f9fa; padding: 20px; border-radius: 6px; margin: 20px 0;'>" +
+                        "<h3 style='color: #2c5aa0; margin-top: 0;'>📍 예약 가능한 빈자리 정보</h3>" +
+                        "<p style='font-size: 16px; margin: 10px 0;'><strong>📅 날짜:</strong> %s</p>" +
+                        "<p style='font-size: 16px; margin: 10px 0;'><strong>🏠 방 번호:</strong> %s</p>" +
+                        "<p style='font-size: 18px; margin: 15px 0; color: #e74c3c;'><strong>⏰ 시간:</strong> %s ~ %s</p>" +
+                        "</div>" +
+
+                        "<div style='text-align: center; margin: 30px 0;'>" +
+                        "<p style='font-size: 16px; margin-bottom: 20px;'>아래 링크를 클릭하여 <strong>빠르게 예약</strong>하세요!</p>" +
+                        "<a href='%s' style='display: inline-block; background-color: #2c5aa0; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; font-weight: bold; font-size: 16px;'>🖱️ 지금 예약하기</a>" +
+                        "</div>" +
+
+                        "<hr style='border: none; height: 1px; background-color: #eee; margin: 30px 0;'>" +
+                        "<p style='text-align: center; color: #666; font-size: 14px;'>빈자리는 선착순이니 서둘러 예약하세요! 🏃‍♂️💨</p>" +
+                        "<p style='text-align: center; color: #999; font-size: 12px; margin-top: 20px;'>ICE 스터디룸 예약 시스템</p>" +
+                        "</div>" +
                         "</body></html>",
                 dto.getEventDate(),
                 dto.getRoomName(),
-                reservationLink,
+                dto.getStartTime(),
+                dto.getEndTime(),
                 reservationLink
         );
+    }
+
+    private void logMonitoringStats() {
+        int total = successCount.get() + failureCount.get() + duplicateCount.get();
+        double successRate = total > 0 ? (double) successCount.get() / total * 100 : 0;
+        long minutesSinceLastProcess = (System.currentTimeMillis() - lastProcessTime) / 60000;
+
+        log.info("[MONITOR] === 이메일 시스템 통계 ===");
+        log.info("[MONITOR] 총 처리: {}건 | 성공: {}건 | 실패: {}건 | 중복: {}건",
+                total, successCount.get(), failureCount.get(), duplicateCount.get());
+        log.info("[MONITOR] 성공률: {:.2f}% | 메모리 사용: {}개 키 | 마지막 처리: {}분 전",
+                successRate, processedMessageIds.size(), minutesSinceLastProcess);
+
+        // 알림 레벨 판정
+        if (successRate < 95.0 && total > 10) {
+            log.error("[ALERT] 성공률 낮음! 현재: {:.2f}%", successRate);
+        }
+        if (processedMessageIds.size() > MAX_PROCESSED_IDS * 0.8) {
+            log.warn("[ALERT] 메모리 사용량 높음! 현재: {}개", processedMessageIds.size());
+        }
+        if (minutesSinceLastProcess > 30) {
+            log.warn("[ALERT] 오랫동안 메시지 없음! {}분 전", minutesSinceLastProcess);
+        }
+    }
+
+    private String maskEmail(String email) {
+        if (email == null || !email.contains("@")) return "***";
+        String[] parts = email.split("@");
+        String username = parts[0];
+        String domain = parts[1];
+
+        if (username.length() <= 2) {
+            return "**@" + domain;
+        }
+        return username.substring(0, 2) + "***@" + domain;
     }
 }

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/dto/VacancyNotificationRequest.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/dto/VacancyNotificationRequest.java
@@ -13,5 +13,9 @@ public class VacancyNotificationRequest {
     private String email;
     private String eventDate;
     private String roomName;
+    private Long ScheduleId;
+    private long timestamp;
+    private String startTime;
+    private String endTime;
 }
 

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/monitoring/EmailSystemHealthChecker.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/monitoring/EmailSystemHealthChecker.java
@@ -1,0 +1,58 @@
+package com.icestudyroom_email.domain.email.infrastructure.kafka.monitoring;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@Slf4j
+public class EmailSystemHealthChecker {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    // 10분마다 시스템 상태 체크
+    @Scheduled(fixedRate = 600000)
+    public void healthCheck() {
+        try {
+            // JVM 메모리 체크
+            Runtime runtime = Runtime.getRuntime();
+            long maxMemory = runtime.maxMemory() / 1024 / 1024; // MB
+            long totalMemory = runtime.totalMemory() / 1024 / 1024;
+            long freeMemory = runtime.freeMemory() / 1024 / 1024;
+            long usedMemory = totalMemory - freeMemory;
+            double memoryUsage = (double) usedMemory / maxMemory * 100;
+
+            System.gc();
+            long afterGcMemory = (runtime.totalMemory() - runtime.freeMemory()) / 1024 / 1024;
+
+            log.info("[HEALTH] === 시스템 헬스체크 ===");
+            log.info("[HEALTH] JVM 메모리: {}MB / {}MB ({:.1f}%)", usedMemory, maxMemory, memoryUsage);
+            log.info("[HEALTH] GC 후 메모리: {}MB", afterGcMemory);
+            log.info("[HEALTH] 애플리케이션 상태: RUNNING");
+            log.info("[HEALTH] 타임스탬프: {}", LocalDateTime.now().format(FORMATTER));
+
+            checkMemoryAlerts(memoryUsage, afterGcMemory, maxMemory);
+
+        } catch (Exception e) {
+            log.error("[HEALTH] 헬스체크 실패: {}", e.getMessage());
+        }
+    }
+
+    private void checkMemoryAlerts(double memoryUsage, long afterGcMemory, long maxMemory) {
+        // 메모리 사용량 알림
+        if (memoryUsage > 90) {
+            log.error("[ALERT] JVM 메모리 사용량 위험! {:.1f}% - 즉시 확인 필요", memoryUsage);
+        } else if (memoryUsage > 80) {
+            log.warn("[ALERT] JVM 메모리 사용량 높음! {:.1f}%", memoryUsage);
+        }
+
+        // GC 후에도 메모리가 높으면 실제 사용량이 많은 것
+        double gcMemoryUsage = (double) afterGcMemory / maxMemory * 100;
+        if (gcMemoryUsage > 70) {
+            log.warn("[ALERT] GC 후에도 메모리 사용량 높음! {:.1f}% - 메모리 누수 의심", gcMemoryUsage);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=email-system
-server.port = 8080
+server.port = 8081
 
 # Gmail SMTP
 spring.mail.host=smtp.gmail.com
@@ -22,6 +22,7 @@ spring.kafka.producer.value-serializer=org.springframework.kafka.support.seriali
 
 # Consumer
 spring.kafka.consumer.group-id=email-service-group
+spring.kafka.consumer.enable-auto-commit=false
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
 spring.kafka.consumer.auto-offset-reset=earliest


### PR DESCRIPTION
## PR 종류
- [x] 리팩토링

## 변경 사항
- 컨슈머 멱등성 보장을 위한 멱등성 키 설정
  - JVM을 활용한 ConcurrentHashMap 사용 
- 멱등성 키를 관리하는 애플리케이션 인메모리 로깅 기능 추가
- 이메일 제목, 본문 내용 상세화 및 가독성 향상

## 관련 이슈
- #524

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용
### 컨슈머 내 중복 이메일 발송 가능 문제 해결 필요

- 애플리케이션이 재시동이나 오류가 발생할 경우 카프카에게 커밋됨을 알리지 못할 경우 동일한 메세지를 처리 가능
  - 일시적 커밋 실패, 새로운 컨슈머 추가 및 컨슈머 삭제로 인한 리밸런스 등에 의해 발생
- 따라서 이를 위해 컨슈머에서 이메일 중복 발송을 방지 필요

멱등성 키를 활용하여 컨슈머의 처리 이후 수동 커밋을 사용하여 중복적인 메일이 발송되지않게 했습니다.

### 멱등성 키 생성을 위한 타임스탬프, 스케줄 ID를 추가
```java
@Getter
@NoArgsConstructor
@AllArgsConstructor
@ToString
public class VacancyNotificationRequest {
    private String email;
    private String eventDate;
    private String roomName;
    
    // 추가된 키
    private Long ScheduleId;
    private long timestamp;
    private String startTime;
    private String endTime;
}
```
- startTime, endTime는 이메일 메세지 본문을 위해 추가했습니다.

### 수동 커밋을 위한 Auto-Commit 비활성화

```yaml
# Consumer
spring.kafka.consumer.group-id=email-service-group
spring.kafka.consumer.enable-auto-commit=false
spring.kafka.consumer.auto-offset-reset=earliest
spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
```

### 컨슈머 멀티스레드 원자성 유지
```java
    private final Set<String> processedMessageIds = ConcurrentHashMap.newKeySet();
    private static final int MAX_PROCESSED_IDS = 50000;
    private final AtomicInteger messageCounter = new AtomicInteger(0);
```
- ConcurrentHashMap을 멀티스레드 환경에서도 안전하게 멱등성 키를 관리할 수 있게 처리해주었습니다.
- 레디스를 추가하기에는 제약적인 문제가 있었고 인프라 추가는 부담스러웠습니다. 따라서 JVM을 사용하기로 했습니다.

### 모니터링 및 로깅 기능 추가
- 따라서 JVM을 활용한 멱등성 키 관리 객체를 구현하게 되었고, 이에 대한 모니터링이 필요했습니다.
```java
@Component
@Slf4j
public class EmailSystemHealthChecker {

    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");

    // 10분마다 시스템 상태 체크
    @Scheduled(fixedRate = 600000)
    public void healthCheck() {
        try {
            // JVM 메모리 체크
            Runtime runtime = Runtime.getRuntime();
            long maxMemory = runtime.maxMemory() / 1024 / 1024; // MB
            long totalMemory = runtime.totalMemory() / 1024 / 1024;
            long freeMemory = runtime.freeMemory() / 1024 / 1024;
            long usedMemory = totalMemory - freeMemory;
            double memoryUsage = (double) usedMemory / maxMemory * 100;

            System.gc();
            long afterGcMemory = (runtime.totalMemory() - runtime.freeMemory()) / 1024 / 1024;

            log.info("[HEALTH] === 시스템 헬스체크 ===");
            log.info("[HEALTH] JVM 메모리: {}MB / {}MB ({:.1f}%)", usedMemory, maxMemory, memoryUsage);
            log.info("[HEALTH] GC 후 메모리: {}MB", afterGcMemory);
            log.info("[HEALTH] 애플리케이션 상태: RUNNING");
            log.info("[HEALTH] 타임스탬프: {}", LocalDateTime.now().format(FORMATTER));

            checkMemoryAlerts(memoryUsage, afterGcMemory, maxMemory);

        } catch (Exception e) {
            log.error("[HEALTH] 헬스체크 실패: {}", e.getMessage());
        }
    }

    private void checkMemoryAlerts(double memoryUsage, long afterGcMemory, long maxMemory) {
        // 메모리 사용량 알림
        if (memoryUsage > 90) {
            log.error("[ALERT] JVM 메모리 사용량 위험! {:.1f}% - 즉시 확인 필요", memoryUsage);
        } else if (memoryUsage > 80) {
            log.warn("[ALERT] JVM 메모리 사용량 높음! {:.1f}%", memoryUsage);
        }

        // GC 후에도 메모리가 높으면 실제 사용량이 많은 것
        double gcMemoryUsage = (double) afterGcMemory / maxMemory * 100;
        if (gcMemoryUsage > 70) {
            log.warn("[ALERT] GC 후에도 메모리 사용량 높음! {:.1f}% - 메모리 누수 의심", gcMemoryUsage);
        }
    }
}
```
### 이메일 본문 변경
<img width="712" height="648" alt="image" src="https://github.com/user-attachments/assets/a9d8cec4-ada6-4bb6-90e3-6a8babd23794" />

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
