### PR TITLE
[BE-#535] 컨슈머 재시도 로직 비활성화 및 커밋 개선

### DIFF
--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/config/KafkaConsumerConfig.java
@@ -18,9 +18,11 @@ import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.util.backoff.ExponentialBackOff;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
 
+@Slf4j
 @Configuration
 @EnableKafka
 public class KafkaConsumerConfig {
@@ -47,14 +49,24 @@ public class KafkaConsumerConfig {
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
             ConsumerFactory<String, Object> consumerFactory) {
-        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
-                kafkaTemplate,
-                (record, ex) -> new TopicPartition(record.topic() + ".DLT", -1)
-        );
 
-        ExponentialBackOff backOff = new ExponentialBackOff(1000L, 2.0);
-        backOff.setMaxElapsedTime(10000L);
-        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+        // 재시도 로직 비활성화 - 멱등성 키 방식 사용으로 인한 중복 방지 우선
+       /*
+       DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+               kafkaTemplate,
+               (record, ex) -> new TopicPartition(record.topic() + ".DLT", -1)
+       );
+
+       ExponentialBackOff backOff = new ExponentialBackOff(1000L, 2.0);
+       backOff.setMaxElapsedTime(10000L);
+       DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+       */
+
+        // 단순 로깅용 에러 핸들러 (재시도 없음)
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler((record, exception) -> {
+            log.error("[KAFKA_ERROR] 메시지 처리 중 예외 발생 - topic: {}, partition: {}, offset: {}, error: {}",
+                    record.topic(), record.partition(), record.offset(), exception.getMessage());
+        });
 
         errorHandler.addNotRetryableExceptions(
                 NullPointerException.class,

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/EmailEventConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/EmailEventConsumer.java
@@ -65,7 +65,6 @@ public class EmailEventConsumer {
             long endTime = System.currentTimeMillis();
 
             successCount.incrementAndGet();
-            ack.acknowledge();
 
             log.info("[SUCCESS] 이메일 발송 성공 - 스케줄:{}, 수신자:{}, 소요시간:{}ms",
                     notificationRequest.getScheduleId(),
@@ -78,20 +77,15 @@ public class EmailEventConsumer {
                     notificationRequest.getScheduleId(),
                     maskEmail(notificationRequest.getEmail()),
                     e.getMessage());
+        } finally {
+            ack.acknowledge();
+            int currentCount = messageCounter.incrementAndGet();
 
-            throw e;
-        }
+            // 100개마다 모니터링
+            if (currentCount % 100 == 0) logMonitoringStats();
 
-        int currentCount = messageCounter.incrementAndGet();
-
-        // 100개마다 모니터링
-        if (currentCount % 100 == 0) {
-            logMonitoringStats();
-        }
-
-        // 500개마다 초간단 정리
-        if (currentCount % 500 == 0) {
-            cleanupOldKeys();
+            // 500개마다 초간단 정리
+            if (currentCount % 500 == 0) cleanupOldKeys();
         }
     }
 


### PR DESCRIPTION
## PR 종류
- [x] 리팩토링

## 변경 사항
- 재시도 로직이 생각과 달리 실패할 경우 무한 반복 될 수 있는 문제점을 확인
- 현재 인프라에서는 재시도 로직을 적절하게 처리해줄 수 있는 방법이 없음
- 이메일 전송은 단 한번 시도하게하며 재시도 로직을 비활성화해주기로 했습니다.

## 관련 이슈

- #535

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

- 필요한 경우 스크린샷을 첨부해주세요.

## 기타

- 추가로 알려야 할 사항이 있다면 적어주세요.
