### PR TITLE
[BE-#576] 개인별 랭킹 알람 제공 구현 & Kafka 디렉토리 구조 리팩토링

### DIFF
--- a/src/main/java/com/icestudyroom_email/domain/common/kafka/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/icestudyroom_email/domain/common/kafka/config/KafkaConsumerConfig.java
@@ -1,4 +1,4 @@
-package com.icestudyroom_email.domain.email.infrastructure.kafka.config;
+package com.icestudyroom_email.domain.common.kafka.config;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;

--- a/src/main/java/com/icestudyroom_email/domain/common/kafka/config/KafkaRankingTopicConfig.java
+++ b/src/main/java/com/icestudyroom_email/domain/common/kafka/config/KafkaRankingTopicConfig.java
@@ -1,4 +1,4 @@
-package com.icestudyroom_email.domain.email.infrastructure.kafka.config;
+package com.icestudyroom_email.domain.common.kafka.config;
 
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/src/main/java/com/icestudyroom_email/domain/common/kafka/producer/KafkaRankingEventPublisher.java
+++ b/src/main/java/com/icestudyroom_email/domain/common/kafka/producer/KafkaRankingEventPublisher.java
@@ -1,7 +1,7 @@
-package com.icestudyroom_email.domain.email.infrastructure.kafka.producer;
+package com.icestudyroom_email.domain.common.kafka.producer;
 
-import com.icestudyroom_email.domain.rankingContract.email.RankingEmailEvent;
-import com.icestudyroom_email.domain.rankingContract.email.RankingEmailEventPublisher;
+import com.icestudyroom_email.domain.rankingContract.RankingEmailEvent;
+import com.icestudyroom_email.domain.rankingContract.forDelete.RankingEmailEventPublisher;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/icestudyroom_email/domain/common/redis/config/RedisConfig.java
+++ b/src/main/java/com/icestudyroom_email/domain/common/redis/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.icestudyroom_email.domain.email.infrastructure.config;
+package com.icestudyroom_email.domain.common.redis.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/icestudyroom_email/domain/common/redis/idempotency/RedisIdempotencyService.java
+++ b/src/main/java/com/icestudyroom_email/domain/common/redis/idempotency/RedisIdempotencyService.java
@@ -1,4 +1,4 @@
-package com.icestudyroom_email.domain.email.infrastructure.idempotency;
+package com.icestudyroom_email.domain.common.redis.idempotency;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -8,7 +8,7 @@ import java.time.Duration;
 
 @Component
 @RequiredArgsConstructor
-public class EmailIdempotencyService {
+public class RedisIdempotencyService {
 
     private final StringRedisTemplate redisTemplate;
 

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/config/EmailRetryConfig.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/config/EmailRetryConfig.java
@@ -1,4 +1,4 @@
-package com.icestudyroom_email.domain.email.infrastructure.kafka.config;
+package com.icestudyroom_email.domain.email.infrastructure.config;
 
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/config/KafkaRankingEmailConsumerConfig.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/config/KafkaRankingEmailConsumerConfig.java
@@ -1,6 +1,6 @@
 package com.icestudyroom_email.domain.email.infrastructure.kafka.config;
 
-import com.icestudyroom_email.domain.rankingContract.email.RankingEmailEvent;
+import com.icestudyroom_email.domain.rankingContract.RankingEmailEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -19,7 +19,7 @@ import java.util.Map;
         havingValue = "true",
         matchIfMissing = false
 )
-public class KafkaRankingConsumerConfig {
+public class KafkaRankingEmailConsumerConfig {
 
     @Bean
     public ConsumerFactory<String, RankingEmailEvent> rankingConsumerFactory

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/RankingEmailConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/kafka/consumer/RankingEmailConsumer.java
@@ -2,13 +2,12 @@ package com.icestudyroom_email.domain.email.infrastructure.kafka.consumer;
 
 import com.icestudyroom_email.domain.email.infrastructure.gmail.EmailService;
 import com.icestudyroom_email.domain.email.infrastructure.gmail.dto.EmailRequest;
-import com.icestudyroom_email.domain.email.infrastructure.idempotency.EmailIdempotencyService;
+import com.icestudyroom_email.domain.common.redis.idempotency.RedisIdempotencyService;
 import com.icestudyroom_email.domain.email.infrastructure.template.RankingEmailTemplateResolver;
-import com.icestudyroom_email.domain.rankingContract.email.RankingEmailEvent;
+import com.icestudyroom_email.domain.rankingContract.RankingEmailEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
@@ -27,7 +26,7 @@ public class RankingEmailConsumer {
 
     private final EmailService emailService;
     private final RankingEmailTemplateResolver templateResolver;
-    private final EmailIdempotencyService idempotencyService;
+    private final RedisIdempotencyService idempotencyService;
 
     @KafkaListener(
             topics = "RANKING_EMAIL_EVENT",

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/template/RankingEmailTemplate.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/template/RankingEmailTemplate.java
@@ -1,7 +1,7 @@
 package com.icestudyroom_email.domain.email.infrastructure.template;
 
 import com.icestudyroom_email.domain.email.infrastructure.gmail.dto.EmailRequest;
-import com.icestudyroom_email.domain.rankingContract.email.RankingEmailEvent;
+import com.icestudyroom_email.domain.rankingContract.RankingEmailEvent;
 import com.icestudyroom_email.domain.rankingContract.RankingEventType;
 
 public interface RankingEmailTemplate {

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/template/RankingEmailTemplateResolver.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/template/RankingEmailTemplateResolver.java
@@ -1,7 +1,7 @@
 package com.icestudyroom_email.domain.email.infrastructure.template;
 
 import com.icestudyroom_email.domain.email.infrastructure.gmail.dto.EmailRequest;
-import com.icestudyroom_email.domain.rankingContract.email.RankingEmailEvent;
+import com.icestudyroom_email.domain.rankingContract.RankingEmailEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/template/Top5EnterEmailTemplate.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/template/Top5EnterEmailTemplate.java
@@ -1,7 +1,7 @@
 package com.icestudyroom_email.domain.email.infrastructure.template;
 
 import com.icestudyroom_email.domain.email.infrastructure.gmail.dto.EmailRequest;
-import com.icestudyroom_email.domain.rankingContract.email.RankingEmailEvent;
+import com.icestudyroom_email.domain.rankingContract.RankingEmailEvent;
 import com.icestudyroom_email.domain.rankingContract.RankingEventType;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/icestudyroom_email/domain/email/infrastructure/template/Top5RankChangeEmailTemplate.java
+++ b/src/main/java/com/icestudyroom_email/domain/email/infrastructure/template/Top5RankChangeEmailTemplate.java
@@ -1,7 +1,7 @@
 package com.icestudyroom_email.domain.email.infrastructure.template;
 
 import com.icestudyroom_email.domain.email.infrastructure.gmail.dto.EmailRequest;
-import com.icestudyroom_email.domain.rankingContract.email.RankingEmailEvent;
+import com.icestudyroom_email.domain.rankingContract.RankingEmailEvent;
 import com.icestudyroom_email.domain.rankingContract.RankingEventType;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/PersonalNotificationPayload.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/PersonalNotificationPayload.java
@@ -1,0 +1,6 @@
+package com.icestudyroom_email.domain.rankingContract;
+
+public record PersonalNotificationPayload(
+        String type
+) {
+}

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/RankingEmailEvent.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/RankingEmailEvent.java
@@ -1,11 +1,10 @@
-package com.icestudyroom_email.domain.rankingContract.email;
-
-import com.icestudyroom_email.domain.rankingContract.RankingEventType;
+package com.icestudyroom_email.domain.rankingContract;
 
 public record RankingEmailEvent(
 
         String eventId,
         RankingEventType eventType,
+        Long memberId,
         String name,
         String email,
         int currentRank,

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/RankingListEvent.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/RankingListEvent.java
@@ -1,9 +1,8 @@
-package com.icestudyroom_email.domain.rankingContract.socket;
+package com.icestudyroom_email.domain.rankingContract;
 
 import java.util.List;
 
 public record RankingListEvent(
-        RankingPeriod period,
         List<WeeklyRankingDto> rankings
 ) {}
 

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/RankingPeriod.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/RankingPeriod.java
@@ -1,4 +1,4 @@
-package com.icestudyroom_email.domain.rankingContract.socket;
+package com.icestudyroom_email.domain.rankingContract;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/WeeklyRankingDto.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/WeeklyRankingDto.java
@@ -1,4 +1,4 @@
-package com.icestudyroom_email.domain.rankingContract.socket;
+package com.icestudyroom_email.domain.rankingContract;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/email/RankingEmailEventPublisher.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/email/RankingEmailEventPublisher.java
@@ -1,6 +1,0 @@
-package com.icestudyroom_email.domain.rankingContract.email;
-
-public abstract class RankingEmailEventPublisher {
-
-    public abstract void publish(RankingEmailEvent event);
-}

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/forDelete/RankingEmailEventPublisher.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/forDelete/RankingEmailEventPublisher.java
@@ -1,0 +1,8 @@
+package com.icestudyroom_email.domain.rankingContract.forDelete;
+
+import com.icestudyroom_email.domain.rankingContract.RankingEmailEvent;
+
+public abstract class RankingEmailEventPublisher {
+
+    public abstract void publish(RankingEmailEvent event);
+}

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/forDelete/RankingEmailInfraTestController.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/forDelete/RankingEmailInfraTestController.java
@@ -1,6 +1,7 @@
-package com.icestudyroom_email.domain.rankingContract.email;
+package com.icestudyroom_email.domain.rankingContract.forDelete;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,10 +11,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/infra-test/email")
 public class RankingEmailInfraTestController {
 
-    private final RankingEmailEventTestPublisher publisher;
+    private final RankingEventTestPublisher publisher;
 
     @PostMapping("/top5")
     public void triggerTop5() {
         publisher.publishTop5EnterEvent();
+    }
+
+    @PostMapping("/personal/{memberId}")
+    public void triggerPersonalNotification(
+            @PathVariable Long memberId
+    ) {
+        publisher.publishPersonalNotificationEvent(memberId);
     }
 }

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/forDelete/RankingEventTestPublisher.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/forDelete/RankingEventTestPublisher.java
@@ -1,13 +1,16 @@
-package com.icestudyroom_email.domain.rankingContract.email;
+package com.icestudyroom_email.domain.rankingContract.forDelete;
 
+import com.icestudyroom_email.domain.rankingContract.RankingEmailEvent;
 import com.icestudyroom_email.domain.rankingContract.RankingEventType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 @Component
 @RequiredArgsConstructor
-public class RankingEmailEventTestPublisher {
+public class RankingEventTestPublisher {
 
     private final KafkaTemplate<String, RankingEmailEvent> kafkaTemplate;
 
@@ -15,6 +18,7 @@ public class RankingEmailEventTestPublisher {
         RankingEmailEvent event = new RankingEmailEvent(
                 "121235",
                 RankingEventType.TOP5_ENTER,
+                1L,
                 "테스트 유저 박다영",
                 "forTestRanking@gmail.com",
                 5,
@@ -25,4 +29,21 @@ public class RankingEmailEventTestPublisher {
         kafkaTemplate.send("RANKING_EMAIL_EVENT", event);
 
     }
+
+    public void publishPersonalNotificationEvent(Long memberId) {
+
+        RankingEmailEvent event = new RankingEmailEvent(
+                UUID.randomUUID().toString(),
+                RankingEventType.TOP5_RANK_CHANGED,
+                memberId,
+                "test-user",
+                "test@test.com",
+                3,
+                5,
+                2
+        );
+
+        kafkaTemplate.send("RANKING_EMAIL_EVENT", event);
+    }
+
 }

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/forDelete/TestController.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/forDelete/TestController.java
@@ -1,5 +1,6 @@
-package com.icestudyroom_email.domain.rankingContract.socket;
+package com.icestudyroom_email.domain.rankingContract.forDelete;
 
+import com.icestudyroom_email.domain.rankingContract.WeeklyRankingDto;
 import com.icestudyroom_email.domain.socket.infrastructure.protocol.ranking.RankingSocketEvent;
 import com.icestudyroom_email.domain.socket.infrastructure.ranking.SocketRankingBroadcaster;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/icestudyroom_email/domain/socket/infrastructure/kafka/consumer/RankingPersonalNotificationConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/socket/infrastructure/kafka/consumer/RankingPersonalNotificationConsumer.java
@@ -1,0 +1,77 @@
+package com.icestudyroom_email.domain.socket.infrastructure.kafka.consumer;
+
+import com.icestudyroom_email.domain.common.redis.idempotency.RedisIdempotencyService;
+import com.icestudyroom_email.domain.rankingContract.RankingEmailEvent;
+import com.icestudyroom_email.domain.socket.infrastructure.ranking.PersonalNotificationBroadcaster;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "feature.kafka.enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
+public class RankingPersonalNotificationConsumer {
+
+    private final RedisIdempotencyService redisIdempotencyService;
+    private final PersonalNotificationBroadcaster personalNotificationBroadcaster;
+
+    @PostConstruct
+    public void init() {
+        log.info("[PersonalNotify] RankingPersonalNotificationConsumer initialized");
+    }
+
+    @KafkaListener(
+            topics = "RANKING_EMAIL_EVENT",
+            groupId = "personal-notification-group",
+            containerFactory = "rankingKafkaListenerContainerFactory"
+    )
+    public void consume(RankingEmailEvent event, Acknowledgment ack) {
+
+        String idempotencyKey = String.format(
+                "notify:personal:%d",
+                event.memberId()
+        );
+
+        try {
+            if (!redisIdempotencyService.isFirst(idempotencyKey, Duration.ofDays(7))) {
+                log.info(
+                        "[PersonalNotify] duplicate ignored. memberId={}",
+                        event.memberId()
+                );
+                ack.acknowledge();
+                return;
+            }
+
+            log.info(
+                    "[PersonalNotify] send personal notification. memberId={}, type={}",
+                    event.memberId(),
+                    event.eventType()
+            );
+
+            personalNotificationBroadcaster.send(
+                    event.memberId(),
+                    event.eventType().name()
+            );
+
+        } catch (Exception e) {
+            log.error(
+                    "[PersonalNotify] error while handling personal notification. memberId={}",
+                    event.memberId(),
+                    e
+            );
+        } finally {
+            ack.acknowledge();
+        }
+    }
+}

--- a/src/main/java/com/icestudyroom_email/domain/socket/infrastructure/ranking/PersonalNotificationBroadcaster.java
+++ b/src/main/java/com/icestudyroom_email/domain/socket/infrastructure/ranking/PersonalNotificationBroadcaster.java
@@ -1,0 +1,38 @@
+package com.icestudyroom_email.domain.socket.infrastructure.ranking;
+
+import com.corundumstudio.socketio.SocketIOServer;
+import com.icestudyroom_email.domain.rankingContract.PersonalNotificationPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PersonalNotificationBroadcaster {
+
+    private final SocketIOServer  socketIOServer;
+
+    private static final String NAMESPACE = "/ranking";
+    private static final String EVENT_NAME = "personal-notification";
+
+    public void send(Long memberId, String type) {
+
+        String room = "member:" + memberId;
+
+        var namespace = socketIOServer.getNamespace(NAMESPACE);
+        var roomOps = namespace.getRoomOperations(room);
+
+        log.info(
+                "[SocketNotify] send personal notification. room={}, type={}, clients={}",
+                room,
+                type,
+                roomOps.getClients().size()
+        );
+
+        roomOps.sendEvent(
+                EVENT_NAME,
+                new PersonalNotificationPayload(type)
+        );
+    }
+}

--- a/src/main/java/com/icestudyroom_email/domain/socket/infrastructure/ranking/RankingQueryService.java
+++ b/src/main/java/com/icestudyroom_email/domain/socket/infrastructure/ranking/RankingQueryService.java
@@ -1,6 +1,6 @@
 package com.icestudyroom_email.domain.socket.infrastructure.ranking;
 
-import com.icestudyroom_email.domain.rankingContract.socket.RankingPeriod;
+import com.icestudyroom_email.domain.rankingContract.RankingPeriod;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.RedisConnectionFactory;

--- a/src/main/java/com/icestudyroom_email/domain/socket/infrastructure/ranking/WeeklyRankingEventListener.java
+++ b/src/main/java/com/icestudyroom_email/domain/socket/infrastructure/ranking/WeeklyRankingEventListener.java
@@ -1,7 +1,7 @@
 package com.icestudyroom_email.domain.socket.infrastructure.ranking;
 
-import com.icestudyroom_email.domain.rankingContract.socket.RankingListEvent;
-import com.icestudyroom_email.domain.rankingContract.socket.WeeklyRankingDto;
+import com.icestudyroom_email.domain.rankingContract.RankingListEvent;
+import com.icestudyroom_email.domain.rankingContract.WeeklyRankingDto;
 import com.icestudyroom_email.domain.socket.infrastructure.protocol.ranking.RankingSocketEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;

--- a/src/test/java/com/icestudyroom_email/domain/test.html
+++ b/src/test/java/com/icestudyroom_email/domain/test.html
@@ -22,6 +22,12 @@
             color: green;
             font-weight: bold;
         }
+        .personal {
+            margin-top: 20px;
+            padding: 10px;
+            border: 1px solid #ddd;
+            background: #fafafa;
+        }
     </style>
 </head>
 <body>
@@ -31,11 +37,19 @@
 
 <ul id="ranking"></ul>
 
+<div class="personal">
+    <h3>🔔 개인 알림</h3>
+    <ul id="personal"></ul>
+</div>
+
 <script>
     console.log("HTML loaded");
 
+    const memberId = 6; // ⚠️ 서버에서 보내는 memberId와 반드시 일치해야 함
+
     const statusEl = document.getElementById("status");
     const rankingEl = document.getElementById("ranking");
+    const personalEl = document.getElementById("personal");
 
     const socket = io("http://localhost:3001/ranking", {
         transports: ["websocket"]
@@ -46,14 +60,17 @@
         statusEl.textContent = "✅ connected";
         statusEl.className = "connected";
 
-        // weekly room 입장
+        // ✅ 기존 기능 유지
         socket.emit("join", "weekly");
+
+        // ✅ 개인 알림용 room
+        socket.emit("join", `member:${memberId}`);
     });
 
+    // ✅ 기존 리스트 실시간 갱신 (절대 수정 ❌)
     socket.on("weekly-ranking-update", (data) => {
         console.log("📡 weekly ranking update:", data);
 
-        // 기존 목록 초기화
         rankingEl.innerHTML = "";
 
         if (!data || data.length === 0) {
@@ -66,6 +83,15 @@
             li.textContent = `🏅 ${item.rank}위 | ${item.memberName}`;
             rankingEl.appendChild(li);
         });
+    });
+
+    // ✅ 개인 알림 (신규 추가)
+    socket.on("personal-notification", (data) => {
+        console.log("🔔 personal notification:", data);
+
+        const li = document.createElement("li");
+        li.textContent = `📌 ${data.type}`;
+        personalEl.prepend(li); // 최신 알림 위로
     });
 
     socket.on("disconnect", () => {


### PR DESCRIPTION
## PR 종류
사용하지 않는 PR 종류는 삭제해주세요
- [x] 새로운 기능
- [x] 리팩토링


## 변경 사항

- 개인별 랭킹 이벤트 발생 시, 사용자에게 실시간 개인 알림을 전달하는 기능을 추가했습니다.
- 개인 알림 기능을 구현하는 과정에서, 기존 Kafka 관련 구조가 인프라별 책임(email / socket)을 명확히 드러내지 않는 것 같아서 기능 구현을 진행하면서 kafka 사용 책임을 인프라 단위로 나누고 관련 파일을 이동시켰습니다.

## 관련 이슈

- #BE-576

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

### ✅ 개인별 알림 기능 추가

- 랭킹 이벤트 발생 시, Kafka 이벤트를 소비하여 특정 사용자(memberId)에게 SocketIO 기반 개인 알림을 전송하도록 구현했습니다.
- Redis 멱등 처리(RedisIdempotencyService)를 적용하여 동일 사용자에 대한 중복 알림 전송을 방지했습니다.

### 📌디렉토리 구조 리팩토링 배경

- 개인 알림 기능을 구현하는 과정에서, **이메일 발송과 실시간 알림이 동일한 Kafka 이벤트를 각기 다른 목적으로 소비**하게 되었습니다.
**이로 인해 Kafka 사용 흐름이 인프라별로 분기되었고, 각 인프라가 이벤트를 어떤 책임으로 처리하는지가 중요해졌습니다.**

- 기존 구조에서는 Kafka 설정과 컨슈머가 공통 영역에 함께 위치해 있어,
이메일 인프라와 소켓 인프라가 각각 어떤 목적의 Kafka 소비자인지 한눈에 파악하기 어렵다고 판단했습니다.

- 이를 개선하기 위해, **공통 설정은 유지하되 email.infrastructure.kafka / socket.infrastructure.kafka 형태로
인프라 목적에 종속된 Kafka 소비 로직을 각 인프라 내부로 이동하도록 구조를 재정렬했습니다.**

- 해당 리팩토링은 구조 변경 자체를 목표로 한 선행 작업이 아니라,
개인 알림 기능을 구현하면서 드러난 인프라 책임 경계 문제를 기능 변경 범위 내에서 함께 개선한 변경 사항입니다.

## 테스트 결과
<img width="963" height="189" alt="스크린샷 2026-02-02 160802" src="https://github.com/user-attachments/assets/839e3886-e1cd-4834-a484-8b4426183176" />

✅ 브라우저 접속 시 SocketIO 연결 정상 여부 확인 (connected 문구 출력)
✅ 테스트 이벤트 발송 시 개인 알림 메시지 수신 확인
  → 이후 프론트엔드에서 해당 알림을 UI로 표현할 예정

Close #576
