### PR TITLE
[BE-#18] 랭킹 이벤트 타입(enum) 이름 변경

### DIFF
--- a/src/main/java/com/icestudyroom_email/domain/contract/ranking/RankingEventType.java
+++ b/src/main/java/com/icestudyroom_email/domain/contract/ranking/RankingEventType.java
@@ -1,6 +1,6 @@
 package com.icestudyroom_email.domain.contract.ranking;
 
 public enum RankingEventType {
-    TOP5_ENTER,
+    TOP6_10_RANK_CHANGED,
     TOP5_RANK_CHANGED
 }

--- a/src/main/java/com/icestudyroom_email/domain/infrastructure/email/template/Top5EnterEmailTemplate.java
+++ b/src/main/java/com/icestudyroom_email/domain/infrastructure/email/template/Top5EnterEmailTemplate.java
@@ -10,7 +10,7 @@ public class Top5EnterEmailTemplate implements RankingEmailTemplate {
 
     @Override
     public RankingEventType supports() {
-        return RankingEventType.TOP5_ENTER;
+        return RankingEventType.TOP6_10_RANK_CHANGED;
     }
 
     @Override

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/RankingEventTestPublisher.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/RankingEventTestPublisher.java
@@ -17,7 +17,7 @@ public class RankingEventTestPublisher {
     public void publishTop5EnterEvent() {
         RankingEmailEvent event = new RankingEmailEvent(
                 "121235",
-                RankingEventType.TOP5_ENTER,
+                RankingEventType.TOP6_10_RANK_CHANGED,
                 1L,
                 "테스트 유저 박다영",
                 "forTestRanking@gmail.com",


### PR DESCRIPTION
## PR 종류

- [x] 리팩토링
- [ ] 문서 수정
➡️해당 코드 머지 이후 도메인 팀원과의 계약 문서 수정 예정입니다. 

## 변경 사항

- 랭킹 이벤트 타입(enum) 정의를 정리하고 명확화했습니다.
- 기존에 혼재되어 있던 의미를 정리하여 랭킹 변화의 “사실”만 표현하도록 이벤트 타입을 단순화했습니다.
- 인프라 레이어에서 이벤트 타입 + payload 기반으로 메일 / 개인 알림 / 메인페이지 실시간 전송을 결정하도록 구조를 유지합니다. 
- 이벤트 타입명 변경을 제외한 다른 작업은 없었습니다. (간단한 변수명 변경) 


`public enum RankingEventType {
    TOP5_RANK_CHANGED,
    TOP6_10_RANK_CHANGED
}` 를

`public enum RankingEventType {
    TOP6_10_RANK_CHANGED,
    TOP6_10_RANK_CHANGED
}`  로 변경 후 연관 파일 수정

## 관련 이슈

- BE-#18

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

- 없습니다.

## 기타

- 없습니다.

Close #18 