### PR TITLE
[BE-#20] kafka Consumer 책임 분리 및 멀티 인스턴스 대비 브로드캐스트 구조 개선

### DIFF
--- a/src/main/java/com/icestudyroom_email/domain/application/socket/RankingBroadcastConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/application/socket/RankingBroadcastConsumer.java
@@ -1,0 +1,58 @@
+package com.icestudyroom_email.domain.application.socket;
+
+import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
+import com.icestudyroom_email.domain.contract.ranking.RankingEventType;
+import com.icestudyroom_email.domain.infrastructure.socket.broadcaster.SocketRankingBroadcaster;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.kafka.support.Acknowledgment;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "feature.kafka.enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
+public class RankingBroadcastConsumer {
+
+    private final SocketRankingBroadcaster SocketRankingBroadcaster;
+
+    @PostConstruct
+    public void init() {
+        log.info("[RankingBroadcast] RankingBroadcastConsumer initialized");
+    }
+
+    @KafkaListener(
+            topics = "RANKING_EMAIL_EVENT",
+            groupId = "ranking-broadcast-group",
+            containerFactory = "rankingKafkaListenerContainerFactory"
+    )
+    public void consume(RankingEmailEvent event, Acknowledgment ack) {
+
+        try {
+            if (event.eventType() == RankingEventType.TOP5_RANK_CHANGED) {
+
+                log.info(
+                        "[RankingBroadcast] TOP5 changed. broadcasting. memberId={}",
+                        event.memberId()
+                );
+
+                SocketRankingBroadcaster.broadcastToAll(
+                        "ranking-update",
+                        event
+                );
+            }
+
+        } catch (Exception e) {
+            log.error("[RankingBroadcast] error", e);
+        } finally {
+            ack.acknowledge();
+        }
+    }
+}

--- a/src/main/java/com/icestudyroom_email/domain/infrastructure/socket/broadcaster/SocketRankingBroadcaster.java
+++ b/src/main/java/com/icestudyroom_email/domain/infrastructure/socket/broadcaster/SocketRankingBroadcaster.java
@@ -30,4 +30,19 @@ public class SocketRankingBroadcaster {
 
         roomOps.sendEvent(event.getEvent(), payload);
     }
+
+    public void broadcastToAll(String eventName, Object payload) {
+
+        var namespace = socketIOServer.getNamespace(NAMESPACE);
+        var broadcastOps = namespace.getBroadcastOperations();
+
+        log.info(
+                "[SocketBroadcast-All] namespace={}, event={}, payload={}",
+                NAMESPACE,
+                eventName,
+                payload
+        );
+
+        broadcastOps.sendEvent(eventName, payload);
+    }
 }

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,14 +1,13 @@
 spring:
   kafka:
-    bootstrap-servers: kafka:9092
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
 
   data:
     redis:
-      host: redis
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
 
 feature:
   kafka:
-    enabled: true
-
+    enabled: ${FEATURE_KAFKA_ENABLED}


### PR DESCRIPTION
## PR 종류

- [x] 리팩토링


## 변경 사항

- 기존 Kafka 이벤트 소비 로직이 하나의 Consumer에 집중되어 있어 이벤트 타입별 책임이 명확하지 않고, 예외 발생 시 로그 추적이 어려운 구조였습니다.
- 또한 배포 환경을 구축하기 위해서 docker 설정 담당하는 application-docekr.yml을 수정했습니다.

- 이를 개선하기 위해 아래 3가지 진행했습니다. 
1️⃣이벤트 타입별 Consumer 책임 분리
2️⃣브로드캐스트 전용 Consumer 분리 (멀티 인스턴스 대비)
3️⃣예외 로깅 체계 정비
4️⃣ application-docekr.yml을 수정

## 관련 이슈

- BE-#20

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용

### 1️⃣ Kafka Consumer 역할 분리
기존: 하나의 Consumer에서 모든 이벤트 타입 처리
변경: 이벤트 타입 기준으로 Consumer 분리

### 2️⃣ 이벤트 타입별 처리 로직 구조 개선
- if-else 기반 분기 구조 정리
- 이벤트 타입별 처리 로직 명확히 분리

### 3️⃣ 브로드캐스트 전용 Consumer 분리 (멀티 인스턴스 대비)
브로드캐스트 로직을 별도 Consumer로 분리했습니다.
분리 이유 : 향후 인스턴스 서버가 2개 이상으로 확장될 경우 대비
- Kafka consumer group 특성상 메시지가 인스턴스별로 분배됨
- Socket 기반 브로드캐스트는 인스턴스별 클라이언트 연결 상태에 영향을 받음

### 4️⃣docker 설정
application-docker.yml을 환경변수 기반으로 배포 환경 대비 수정

## 기타

- 기능 추가거나 로직 수정은 진행하지 않고 브로드캐스트 분리와 에러로깅만 추가했습니다.

Close #20 
