### PR TITLE
[BE-#633]랭킹 Kafka 이벤트 계약 정리 및 개인/전체 알림 Consumer 분리 구현

### DIFF
--- a/src/main/java/com/icestudyroom_email/domain/application/email/RankingEmailConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/application/email/RankingEmailConsumer.java
@@ -1,10 +1,10 @@
 package com.icestudyroom_email.domain.application.email;
 
+import com.icestudyroom_email.domain.contract.ranking.RankingChangedEvent;
 import com.icestudyroom_email.domain.infrastructure.email.gmail.EmailService;
 import com.icestudyroom_email.domain.infrastructure.email.gmail.EmailRequest;
 import com.icestudyroom_email.domain.infrastructure.redis.idempotency.RedisIdempotencyService;
 import com.icestudyroom_email.domain.infrastructure.email.template.RankingEmailTemplateResolver;
-import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -29,11 +29,11 @@ public class RankingEmailConsumer {
     private final RedisIdempotencyService idempotencyService;
 
     @KafkaListener(
-            topics = "RANKING_EMAIL_EVENT",
+            topics = "RANKING_USER_CHANGED_EVENT",
             groupId = "email-group",
-            containerFactory = "rankingKafkaListenerContainerFactory"
+            containerFactory = "rankingChangedKafkaListenerContainerFactory"
     )
-    public void consume(RankingEmailEvent event, Acknowledgment ack) {
+    public void consume(RankingChangedEvent event, Acknowledgment ack) {
 
         String checkDuplicatedkey = "email:sent:" + event.eventId();
 

--- a/src/main/java/com/icestudyroom_email/domain/application/socket/RankingBroadcastConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/application/socket/RankingBroadcastConsumer.java
@@ -1,7 +1,6 @@
 package com.icestudyroom_email.domain.application.socket;
 
-import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
-import com.icestudyroom_email.domain.contract.ranking.RankingEventType;
+import com.icestudyroom_email.domain.contract.ranking.RankingListUpdatedEvent;
 import com.icestudyroom_email.domain.infrastructure.socket.broadcaster.SocketRankingBroadcaster;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -29,25 +28,20 @@ public class RankingBroadcastConsumer {
     }
 
     @KafkaListener(
-            topics = "RANKING_EMAIL_EVENT",
+            topics = "RANKING_LIST_UPDATED_EVENT",
             groupId = "ranking-broadcast-group",
-            containerFactory = "rankingKafkaListenerContainerFactory"
+            containerFactory = "rankingListKafkaListenerContainerFactory"
     )
-    public void consume(RankingEmailEvent event, Acknowledgment ack) {
+    public void consume(RankingListUpdatedEvent event, Acknowledgment ack) {
 
         try {
-            if (event.eventType() == RankingEventType.TOP5_RANK_CHANGED) {
+            log.info("[RankingBroadcast] broadcasting ranking list. periodKey={}",
+                    event.periodKey());
 
-                log.info(
-                        "[RankingBroadcast] TOP5 changed. broadcasting. memberId={}",
-                        event.memberId()
-                );
-
-                SocketRankingBroadcaster.broadcastToAll(
-                        "ranking-update",
-                        event
-                );
-            }
+            SocketRankingBroadcaster.broadcastToAll(
+                    "ranking-update",
+                    event.rankingList()
+            );
 
         } catch (Exception e) {
             log.error("[RankingBroadcast] error", e);

--- a/src/main/java/com/icestudyroom_email/domain/application/socket/RankingPersonalNotificationConsumer.java
+++ b/src/main/java/com/icestudyroom_email/domain/application/socket/RankingPersonalNotificationConsumer.java
@@ -1,7 +1,7 @@
 package com.icestudyroom_email.domain.application.socket;
 
+import com.icestudyroom_email.domain.contract.ranking.RankingChangedEvent;
 import com.icestudyroom_email.domain.infrastructure.redis.idempotency.RedisIdempotencyService;
-import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
 import com.icestudyroom_email.domain.infrastructure.socket.broadcaster.PersonalNotificationBroadcaster;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -32,11 +32,11 @@ public class RankingPersonalNotificationConsumer {
     }
 
     @KafkaListener(
-            topics = "RANKING_EMAIL_EVENT",
+            topics = "RANKING_USER_CHANGED_EVENT",
             groupId = "personal-notification-group",
-            containerFactory = "rankingKafkaListenerContainerFactory"
+            containerFactory = "rankingChangedKafkaListenerContainerFactory"
     )
-    public void consume(RankingEmailEvent event, Acknowledgment ack) {
+    public void consume(RankingChangedEvent event, Acknowledgment ack) {
 
         String idempotencyKey = String.format(
                 "notify:personal:%d",

--- a/src/main/java/com/icestudyroom_email/domain/contract/ranking/RankingChangedEvent.java
+++ b/src/main/java/com/icestudyroom_email/domain/contract/ranking/RankingChangedEvent.java
@@ -1,13 +1,19 @@
 package com.icestudyroom_email.domain.contract.ranking;
 
-public record RankingEmailEvent(
+
+public record RankingChangedEvent(
 
         String eventId,
         RankingEventType eventType,
+        String periodKey,
+
         Long memberId,
         String name,
         String email,
+
         int currentRank,
         Integer previousRank,
+        int score,
         Integer gapWithUpper
+
 ) {}

--- a/src/main/java/com/icestudyroom_email/domain/contract/ranking/RankingListUpdatedEvent.java
+++ b/src/main/java/com/icestudyroom_email/domain/contract/ranking/RankingListUpdatedEvent.java
@@ -1,0 +1,11 @@
+package com.icestudyroom_email.domain.contract.ranking;
+
+import java.util.List;
+
+public record RankingListUpdatedEvent(
+
+        String eventId,
+        String periodKey,
+        List<WeeklyRankingDto> rankingList
+
+) {}

--- a/src/main/java/com/icestudyroom_email/domain/contract/ranking/WeeklyRankingDto.java
+++ b/src/main/java/com/icestudyroom_email/domain/contract/ranking/WeeklyRankingDto.java
@@ -1,14 +1,7 @@
 package com.icestudyroom_email.domain.contract.ranking;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class WeeklyRankingDto {
-
-    private int rank;
-    private Long memberId; // Redis에 저장되는 사용자 식별자
-    private String name; // 화면 표시용
-    private int score;
-}
+public record WeeklyRankingDto(
+        int rank,
+        String name,
+        int score
+) {}

--- a/src/main/java/com/icestudyroom_email/domain/infrastructure/email/template/RankingEmailTemplate.java
+++ b/src/main/java/com/icestudyroom_email/domain/infrastructure/email/template/RankingEmailTemplate.java
@@ -1,10 +1,10 @@
 package com.icestudyroom_email.domain.infrastructure.email.template;
 
+import com.icestudyroom_email.domain.contract.ranking.RankingChangedEvent;
 import com.icestudyroom_email.domain.infrastructure.email.gmail.EmailRequest;
-import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
 import com.icestudyroom_email.domain.contract.ranking.RankingEventType;
 
 public interface RankingEmailTemplate {
     RankingEventType supports();
-    EmailRequest create(RankingEmailEvent event);
+    EmailRequest create(RankingChangedEvent event);
 }

--- a/src/main/java/com/icestudyroom_email/domain/infrastructure/email/template/RankingEmailTemplateResolver.java
+++ b/src/main/java/com/icestudyroom_email/domain/infrastructure/email/template/RankingEmailTemplateResolver.java
@@ -1,7 +1,7 @@
 package com.icestudyroom_email.domain.infrastructure.email.template;
 
+import com.icestudyroom_email.domain.contract.ranking.RankingChangedEvent;
 import com.icestudyroom_email.domain.infrastructure.email.gmail.EmailRequest;
-import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +13,7 @@ public class RankingEmailTemplateResolver {
 
     private final List<RankingEmailTemplate> templates;
 
-    public EmailRequest resolve(RankingEmailEvent event) {
+    public EmailRequest resolve(RankingChangedEvent event) {
         return templates.stream()
                 .filter(t -> t.supports() == event.eventType())
                 .findFirst()

--- a/src/main/java/com/icestudyroom_email/domain/infrastructure/email/template/Top5EnterEmailTemplate.java
+++ b/src/main/java/com/icestudyroom_email/domain/infrastructure/email/template/Top5EnterEmailTemplate.java
@@ -1,7 +1,7 @@
 package com.icestudyroom_email.domain.infrastructure.email.template;
 
+import com.icestudyroom_email.domain.contract.ranking.RankingChangedEvent;
 import com.icestudyroom_email.domain.infrastructure.email.gmail.EmailRequest;
-import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
 import com.icestudyroom_email.domain.contract.ranking.RankingEventType;
 import org.springframework.stereotype.Component;
 
@@ -14,7 +14,7 @@ public class Top5EnterEmailTemplate implements RankingEmailTemplate {
     }
 
     @Override
-    public EmailRequest create(RankingEmailEvent event) {
+    public EmailRequest create(RankingChangedEvent event) {
         return new EmailRequest(
                 event.email(),
                 "🏆 TOP5 진입! 열공하셨네요!! 🏆",

--- a/src/main/java/com/icestudyroom_email/domain/infrastructure/email/template/Top5RankChangeEmailTemplate.java
+++ b/src/main/java/com/icestudyroom_email/domain/infrastructure/email/template/Top5RankChangeEmailTemplate.java
@@ -1,7 +1,7 @@
 package com.icestudyroom_email.domain.infrastructure.email.template;
 
+import com.icestudyroom_email.domain.contract.ranking.RankingChangedEvent;
 import com.icestudyroom_email.domain.infrastructure.email.gmail.EmailRequest;
-import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
 import com.icestudyroom_email.domain.contract.ranking.RankingEventType;
 import org.springframework.stereotype.Component;
 
@@ -12,7 +12,7 @@ public class Top5RankChangeEmailTemplate implements RankingEmailTemplate{
     public RankingEventType supports() { return RankingEventType.TOP5_RANK_CHANGED; }
 
     @Override
-    public EmailRequest create(RankingEmailEvent event) {
+    public EmailRequest create(RankingChangedEvent event) {
 
         boolean isUp = event.previousRank() != null
                 && event.currentRank() < event.previousRank();

--- a/src/main/java/com/icestudyroom_email/domain/infrastructure/kafka/config/KafkaRankingChangedConsumerConfig.java
+++ b/src/main/java/com/icestudyroom_email/domain/infrastructure/kafka/config/KafkaRankingChangedConsumerConfig.java
@@ -1,6 +1,6 @@
 package com.icestudyroom_email.domain.infrastructure.kafka.config;
 
-import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
+import com.icestudyroom_email.domain.contract.ranking.RankingChangedEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -19,33 +19,34 @@ import java.util.Map;
         havingValue = "true",
         matchIfMissing = false
 )
-public class KafkaRankingEmailConsumerConfig {
+public class KafkaRankingChangedConsumerConfig {
 
     @Bean
-    public ConsumerFactory<String, RankingEmailEvent> rankingConsumerFactory
-            (KafkaProperties kafkaProperties) {
+    public ConsumerFactory<String, RankingChangedEvent> rankingChangedConsumerFactory(
+            KafkaProperties kafkaProperties) {
 
         Map<String, Object> props = kafkaProperties.buildConsumerProperties(null);
 
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, RankingEmailEvent.class.getName());
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, RankingChangedEvent.class.getName());
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
         props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
 
-            return new DefaultKafkaConsumerFactory<>(props);
+        return new DefaultKafkaConsumerFactory<>(props);
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, RankingEmailEvent> rankingKafkaListenerContainerFactory(
-            ConsumerFactory<String, RankingEmailEvent> rankingConsumerFactory) {
+    public ConcurrentKafkaListenerContainerFactory<String, RankingChangedEvent>
+    rankingChangedKafkaListenerContainerFactory(
+            ConsumerFactory<String, RankingChangedEvent> factory) {
 
-        ConcurrentKafkaListenerContainerFactory<String, RankingEmailEvent> factory =
+        ConcurrentKafkaListenerContainerFactory<String, RankingChangedEvent> containerFactory =
                 new ConcurrentKafkaListenerContainerFactory<>();
 
-        factory.setConsumerFactory(rankingConsumerFactory);
-        factory.getContainerProperties()
+        containerFactory.setConsumerFactory(factory);
+        containerFactory.getContainerProperties()
                 .setAckMode(ContainerProperties.AckMode.MANUAL);
 
-        return factory;
+        return containerFactory;
     }
 }

--- a/src/main/java/com/icestudyroom_email/domain/infrastructure/kafka/config/KafkaRankingListUpdatedConsumerConfig.java
+++ b/src/main/java/com/icestudyroom_email/domain/infrastructure/kafka/config/KafkaRankingListUpdatedConsumerConfig.java
@@ -1,0 +1,53 @@
+package com.icestudyroom_email.domain.infrastructure.kafka.config;
+
+import com.icestudyroom_email.domain.contract.ranking.RankingListUpdatedEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.Map;
+
+@Configuration
+@ConditionalOnProperty(
+        name = "feature.kafka.enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
+public class KafkaRankingListUpdatedConsumerConfig {
+
+    @Bean
+    public ConsumerFactory<String, RankingListUpdatedEvent> rankingListConsumerFactory(
+            KafkaProperties kafkaProperties) {
+
+        Map<String, Object> props = kafkaProperties.buildConsumerProperties(null);
+
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, RankingListUpdatedEvent.class.getName());
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, RankingListUpdatedEvent>
+    rankingListKafkaListenerContainerFactory(
+            ConsumerFactory<String, RankingListUpdatedEvent> factory) {
+
+        ConcurrentKafkaListenerContainerFactory<String, RankingListUpdatedEvent> containerFactory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+
+        containerFactory.setConsumerFactory(factory);
+        containerFactory.getContainerProperties()
+                .setAckMode(ContainerProperties.AckMode.MANUAL);
+
+        return containerFactory;
+    }
+}

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/RankingEmailEventPublisher.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/RankingEmailEventPublisher.java
@@ -1,8 +1,0 @@
-package com.icestudyroom_email.domain.rankingContract.forTest;
-
-import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
-
-public abstract class RankingEmailEventPublisher {
-
-    public abstract void publish(RankingEmailEvent event);
-}

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/RankingEmailInfraTestController.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/RankingEmailInfraTestController.java
@@ -1,6 +1,7 @@
 package com.icestudyroom_email.domain.rankingContract.forTest;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,19 +10,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/infra-test/email")
+@Profile("local")
 public class RankingEmailInfraTestController {
 
-    private final RankingEventTestPublisher publisher;
+    private final RankingEventTestPublisher userPublisher;
+    private final RankingListUpdatedTestPublisher listPublisher;
 
-    @PostMapping("/top5")
+    @PostMapping("/user/top5")
     public void triggerTop5() {
-        publisher.publishTop5EnterEvent();
+        userPublisher.publish();
     }
 
-    @PostMapping("/personal/{memberId}")
-    public void triggerPersonalNotification(
-            @PathVariable Long memberId
-    ) {
-        publisher.publishPersonalNotificationEvent(memberId);
+    @PostMapping("/list/update")
+    public void triggerListUpdate() {
+        listPublisher.publish();
     }
 }

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/RankingEventTestPublisher.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/RankingEventTestPublisher.java
@@ -1,6 +1,6 @@
 package com.icestudyroom_email.domain.rankingContract.forTest;
 
-import com.icestudyroom_email.domain.contract.ranking.RankingEmailEvent;
+import com.icestudyroom_email.domain.contract.ranking.RankingChangedEvent;
 import com.icestudyroom_email.domain.contract.ranking.RankingEventType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -12,38 +12,23 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class RankingEventTestPublisher {
 
-    private final KafkaTemplate<String, RankingEmailEvent> kafkaTemplate;
+    private final KafkaTemplate<Object, Object> kafkaTemplate;
 
-    public void publishTop5EnterEvent() {
-        RankingEmailEvent event = new RankingEmailEvent(
-                "121235",
-                RankingEventType.TOP6_10_RANK_CHANGED,
-                1L,
-                "테스트 유저 박다영",
-                "forTestRanking@gmail.com",
-                5,
-                6,
-                10);
+    public void publish() {
 
-
-        kafkaTemplate.send("RANKING_EMAIL_EVENT", event);
-
-    }
-
-    public void publishPersonalNotificationEvent(Long memberId) {
-
-        RankingEmailEvent event = new RankingEmailEvent(
+        RankingChangedEvent event = new RankingChangedEvent(
                 UUID.randomUUID().toString(),
                 RankingEventType.TOP5_RANK_CHANGED,
-                memberId,
-                "test-user",
-                "test@test.com",
-                3,
-                5,
-                2
+                "2026-W08",
+                6L,
+                "테스트 유저 박다영",
+                "pdayoung0402@hufs.ac.kr",
+                4,
+                6,
+                1320,
+                50
         );
 
-        kafkaTemplate.send("RANKING_EMAIL_EVENT", event);
+        kafkaTemplate.send("RANKING_USER_CHANGED_EVENT", event);
     }
-
 }

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/RankingListUpdatedTestPublisher.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/RankingListUpdatedTestPublisher.java
@@ -1,0 +1,37 @@
+package com.icestudyroom_email.domain.rankingContract.forTest;
+
+import com.icestudyroom_email.domain.contract.ranking.RankingListUpdatedEvent;
+import com.icestudyroom_email.domain.contract.ranking.WeeklyRankingDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@Profile("local")
+@RequiredArgsConstructor
+public class RankingListUpdatedTestPublisher {
+
+    private final KafkaTemplate<Object, Object> kafkaTemplate;
+
+    public void publish() {
+
+        RankingListUpdatedEvent event =
+                new RankingListUpdatedEvent(
+                        UUID.randomUUID().toString(),
+                        "2026-W08",
+                        List.of(
+                                new WeeklyRankingDto(1,"박*영", 1500),
+                                new WeeklyRankingDto(2,"김*준", 1400),
+                                new WeeklyRankingDto(3,"김*희", 1400),
+                                new WeeklyRankingDto(4,"변*빈", 1400),
+                                new WeeklyRankingDto(5,"장*연", 1400)
+                        )
+                );
+
+        kafkaTemplate.send("RANKING_LIST_UPDATED_EVENT", event);
+    }
+}

--- a/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/TestController.java
+++ b/src/main/java/com/icestudyroom_email/domain/rankingContract/forTest/TestController.java
@@ -29,11 +29,11 @@ public class TestController {
 
     private List<WeeklyRankingDto> mockWeeklyRanking() {
         return List.of(
-                new WeeklyRankingDto(1, 1001L, "박*영", 150),
-                new WeeklyRankingDto(2, 1002L, "김*준", 120),
-                new WeeklyRankingDto(3, 1003L, "임*연", 95),
-                new WeeklyRankingDto(4, 1004L, "김*희", 80),
-                new WeeklyRankingDto(5, 1005L, "장*연", 70)
+                new WeeklyRankingDto(1, "박*영", 150),
+                new WeeklyRankingDto(2, "김*준", 120),
+                new WeeklyRankingDto(3, "임*연", 95),
+                new WeeklyRankingDto(4, "김*희", 80),
+                new WeeklyRankingDto(5, "장*연", 70)
         );
     }
 }

--- a/src/test/java/com/icestudyroom_email/domain/test.html
+++ b/src/test/java/com/icestudyroom_email/domain/test.html
@@ -45,7 +45,7 @@
 <script>
     console.log("HTML loaded");
 
-    const memberId = 6; // ⚠️ 서버에서 보내는 memberId와 반드시 일치해야 함
+    const memberId = 6;
 
     const statusEl = document.getElementById("status");
     const rankingEl = document.getElementById("ranking");
@@ -60,16 +60,13 @@
         statusEl.textContent = "✅ connected";
         statusEl.className = "connected";
 
-        // ✅ 기존 기능 유지
         socket.emit("join", "weekly");
-
-        // ✅ 개인 알림용 room
         socket.emit("join", `member:${memberId}`);
     });
 
-    // ✅ 기존 리스트 실시간 갱신 (절대 수정 ❌)
-    socket.on("weekly-ranking-update", (data) => {
-        console.log("📡 weekly ranking update:", data);
+    // ✅ 서버 이벤트 이름에 맞춤
+    socket.on("ranking-update", (data) => {
+        console.log("📡 ranking update:", data);
 
         rankingEl.innerHTML = "";
 
@@ -80,18 +77,20 @@
 
         data.forEach(item => {
             const li = document.createElement("li");
-            li.textContent = `🏅 ${item.rank}위 | ${item.memberName}`;
+
+            // ✅ score 제거
+            li.textContent = `🏅 ${item.rank}위 | ${item.name}`;
+
             rankingEl.appendChild(li);
         });
     });
 
-    // ✅ 개인 알림 (신규 추가)
     socket.on("personal-notification", (data) => {
         console.log("🔔 personal notification:", data);
 
         const li = document.createElement("li");
         li.textContent = `📌 ${data.type}`;
-        personalEl.prepend(li); // 최신 알림 위로
+        personalEl.prepend(li);
     });
 
     socket.on("disconnect", () => {


### PR DESCRIPTION
## PR 종류

- [x] 기능 개선
- [x] 리팩토링


## 변경 사항

- 🔴기존 구조🔴 
도메인 인스턴스에서 하나의 이벤트를 발행하고 이를 인프라 레포에서 재 가공해서 2개의 이벤트로 분기가 되는 형태
➡️ 문제점 : 인프라 레포가 이벤트를 해석하는 행위 발생 & 확장 시 복잡도 증가 우려 & 테스트 및 장애 발생 트래킹 어려움

- 🟢변경하려는 구조🟢
도메인 인스턴스에서 목적에 맞는 이벤트 직접 발행
1️⃣ RANKING_USER_CHANGED_EVENT (개인 알림용)
2️⃣ RANKING_LIST_UPDATED_EVENT (전체 브로드캐스트용)
인프라 레포는 단순 소비 및 전달만 수행하도록 수정

⭐결론 : 기존 단일 이벤트를 인프라에서 재가공하던 구조에서,
도메인 주도 이벤트 발행 구조로 변경하여 책임을 명확히 분리하였습니다.이에 따라 구조를 개선하였습니다.

## 관련 이슈

- BE-#24

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [ ] 관련 문서를 업데이트했나요?
➡️dev에 머지 이후에 프론트 연동 문서에 반영 후 해당 팀원에게 전달하겠습니다!
- [x] 코드 컨벤션을 지켰나요?

## 상세 내용
###  1️⃣ 이벤트 계약(Contract) 정의
- `RankingChangedEvent` 정의 (개인 랭킹 변동 이벤트)
- `RankingListUpdatedEvent` 정의 (전체 랭킹 리스트 갱신 이벤트)
- `WeeklyRankingDto` record 기반 정리
- `RankingEventType` enum 정리
→ 도메인 팀과 공유 가능한 명확한 Kafka 이벤트 스펙 확립

### 2️⃣ Kafka Consumer 구조 개선
- 개인 알림용 `RankingPersonalNotificationConsumer` 구현
- 전체 브로드캐스트용 `RankingBroadcastConsumer` 분리
- 이벤트별 `KafkaListenerContainerFactory` 분리 구성
→ 이벤트 타입별 책임 분리 및 가독성/확장성 개선

### 3️⃣ 테스트 코드 추가 및 수정
- Kafka Test Publisher 추가
- 테스트용 Controller 추가
- `test.html` 추가 (Socket 동작 검증용)

### 🎯 개선 목적
- 도메인 인스턴스와의 이벤트 계약 명확화
- Kafka 이벤트 타입별 책임 분리

###📎 참고

이벤트 필드명은 도메인 인스턴스와 반드시 동일해야 합니다.
Kafka Topic:
- `RANKING_USER_CHANGED_EVENT`
- `RANKING_LIST_UPDATED_EVENT`

## 기타
- 테스트 완료했습니다.
<img width="938" height="678" alt="스크린샷 2026-02-26 210421" src="https://github.com/user-attachments/assets/f07a3a4d-026c-481d-a28b-6ee006167f4a" />

Close #24
